### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-rxjava-1/pom.xml
+++ b/opentracing-rxjava-1/pom.xml
@@ -31,6 +31,7 @@
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
       <version>1.3.8</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/opentracing-rxjava-2/pom.xml
+++ b/opentracing-rxjava-2/pom.xml
@@ -31,6 +31,7 @@
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>2.2.11</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.