### PR TITLE
#11 Add TracingSubscriber for RxJava2 Flowable usecases

### DIFF
--- a/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/RxTracer.java
+++ b/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/RxTracer.java
@@ -17,14 +17,13 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
-import io.reactivex.Observer;
-import io.reactivex.disposables.Disposable;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-class AbstractTracingObserver<T> implements Observer<T> {
+final class RxTracer {
 
   static final String COMPONENT_NAME = "rxjava-2";
 
@@ -32,32 +31,25 @@ class AbstractTracingObserver<T> implements Observer<T> {
   private final Tracer tracer;
   private volatile Span span;
 
-  AbstractTracingObserver(String operationName, Tracer tracer) {
+  RxTracer(String operationName, Tracer tracer) {
     this.operationName = operationName;
     this.tracer = tracer;
   }
 
-  @Override
-  public void onSubscribe(Disposable d) {
+  void onSubscribe() {
     span = tracer.buildSpan(operationName)
-        .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME).start();
+            .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME).start();
     Scope scope = tracer.activateSpan(span);
     SpanHolder.set(scope, span);
   }
 
-  @Override
-  public void onNext(T t) {
-  }
-
-  @Override
-  public void onError(Throwable t) {
+  void onError(Throwable t) {
     onError(t, span);
     span.finish();
     SpanHolder.clear();
   }
 
-  @Override
-  public void onComplete() {
+  void onComplete() {
     span.finish();
     SpanHolder.clear();
   }

--- a/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingConsumer.java
+++ b/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingConsumer.java
@@ -14,6 +14,7 @@
 package io.opentracing.rxjava2;
 
 import io.opentracing.Tracer;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
@@ -23,8 +24,9 @@ import io.reactivex.internal.observers.LambdaObserver;
 /**
  * Tracing decorator for RxJava {@link Consumer}
  */
-public class TracingConsumer<T> extends AbstractTracingObserver<T> implements Disposable {
+public class TracingConsumer<T> implements Observer<T>, Disposable {
 
+  private final RxTracer rxTracer;
   private final LambdaObserver<T> lambdaObserver;
 
   public TracingConsumer(String operationName, Tracer tracer) {
@@ -50,7 +52,7 @@ public class TracingConsumer<T> extends AbstractTracingObserver<T> implements Di
       Action onComplete, Consumer<? super Disposable> onSubscribe, String operationName,
       Tracer tracer) {
 
-    super(operationName, tracer);
+    rxTracer = new RxTracer(operationName, tracer);
 
     requireNonNull(onNext, "onNext can not be null");
     requireNonNull(onError, "onError can not be null");
@@ -66,7 +68,7 @@ public class TracingConsumer<T> extends AbstractTracingObserver<T> implements Di
     try {
       lambdaObserver.onSubscribe(d);
     } finally {
-      super.onSubscribe(d);
+      rxTracer.onSubscribe();
     }
   }
 
@@ -80,9 +82,8 @@ public class TracingConsumer<T> extends AbstractTracingObserver<T> implements Di
     try {
       lambdaObserver.onError(t);
     } finally {
-      super.onError(t);
+      rxTracer.onError(t);
     }
-
   }
 
   @Override
@@ -90,7 +91,7 @@ public class TracingConsumer<T> extends AbstractTracingObserver<T> implements Di
     try {
       lambdaObserver.onComplete();
     } finally {
-      super.onComplete();
+      rxTracer.onComplete();
     }
   }
 

--- a/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingObserver.java
+++ b/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingObserver.java
@@ -20,14 +20,14 @@ import io.reactivex.disposables.Disposable;
 /**
  * Tracing decorator for RxJava {@link Observer}
  */
-public class TracingObserver<T> extends AbstractTracingObserver<T> implements Disposable {
+public class TracingObserver<T> implements Observer<T>, Disposable {
 
   private Disposable upstream;
+  private final RxTracer rxTracer;
   private final Observer<T> observer;
 
-
   public TracingObserver(Observer<T> observer, String operationName, Tracer tracer) {
-    super(operationName, tracer);
+    rxTracer = new RxTracer(operationName, tracer);
     this.observer = observer;
   }
 
@@ -47,7 +47,7 @@ public class TracingObserver<T> extends AbstractTracingObserver<T> implements Di
     try {
       observer.onSubscribe(this);
     } finally {
-      super.onSubscribe(d);
+      rxTracer.onSubscribe();
     }
   }
 
@@ -61,7 +61,7 @@ public class TracingObserver<T> extends AbstractTracingObserver<T> implements Di
     try {
       observer.onError(t);
     } finally {
-      super.onError(t);
+      rxTracer.onError(t);
     }
   }
 
@@ -70,7 +70,7 @@ public class TracingObserver<T> extends AbstractTracingObserver<T> implements Di
     try {
       observer.onComplete();
     } finally {
-      super.onComplete();
+      rxTracer.onComplete();
     }
   }
 }

--- a/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingSubscriber.java
+++ b/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingSubscriber.java
@@ -23,6 +23,9 @@ import io.reactivex.internal.operators.flowable.FlowableInternalHelper;
 import io.reactivex.internal.subscribers.LambdaSubscriber;
 import org.reactivestreams.Subscription;
 
+/**
+ * Tracing decorator for RxJava {@link FlowableSubscriber}
+ */
 public class TracingSubscriber<T> implements FlowableSubscriber<T>, Subscription {
 
     private Subscription upstream;

--- a/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingSubscriber.java
+++ b/opentracing-rxjava-2/src/main/java/io/opentracing/rxjava2/TracingSubscriber.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.rxjava2;
+
+import io.opentracing.Tracer;
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.internal.operators.flowable.FlowableInternalHelper;
+import io.reactivex.internal.subscribers.LambdaSubscriber;
+import org.reactivestreams.Subscription;
+
+public class TracingSubscriber<T> implements FlowableSubscriber<T>, Subscription {
+
+    private Subscription upstream;
+    private final RxTracer rxTracer;
+    private final FlowableSubscriber<T> subscriber;
+
+    private TracingSubscriber(FlowableSubscriber<T> subscriber, String operationName, Tracer tracer) {
+        rxTracer = new RxTracer(operationName, tracer);
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public void request(long l) {
+        upstream.request(l);
+    }
+
+    @Override
+    public void cancel() {
+        upstream.cancel();
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        upstream = s;
+        try {
+            subscriber.onSubscribe(this);
+        } finally {
+            rxTracer.onSubscribe();
+        }
+    }
+
+    @Override
+    public void onNext(T o) {
+        subscriber.onNext(o);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        try {
+            subscriber.onError(t);
+        } finally {
+            rxTracer.onError(t);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        try {
+            subscriber.onComplete();
+        } finally {
+            rxTracer.onComplete();
+        }
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            String operationName,
+            Tracer tracer) {
+        return create(Functions.emptyConsumer(), Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION,
+                FlowableInternalHelper.RequestMax.INSTANCE, operationName, tracer);
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            Consumer<? super T> onNext,
+            String operationName,
+            Tracer tracer) {
+        return create(onNext, Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION,
+                FlowableInternalHelper.RequestMax.INSTANCE, operationName, tracer);
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            String operationName,
+            Tracer tracer) {
+        return create(onNext, onError, Functions.EMPTY_ACTION, FlowableInternalHelper.RequestMax.INSTANCE,
+                operationName, tracer);
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Action onComplete,
+            String operationName,
+            Tracer tracer) {
+        return create(onNext, onError, onComplete, FlowableInternalHelper.RequestMax.INSTANCE, operationName, tracer);
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            Consumer<? super T> onNext,
+            Consumer<? super Throwable> onError,
+            Action onComplete,
+            Consumer<? super Subscription> onSubscribe,
+            String operationName,
+            Tracer tracer) {
+        ObjectHelper.requireNonNull(onNext, "onNext is null");
+        ObjectHelper.requireNonNull(onError, "onError is null");
+        ObjectHelper.requireNonNull(onComplete, "onComplete is null");
+        ObjectHelper.requireNonNull(onSubscribe, "onSubscribe is null");
+        ObjectHelper.requireNonNull(tracer, "tracer can not be null");
+
+        return create(new LambdaSubscriber<>(onNext, onError, onComplete, onSubscribe), operationName, tracer);
+    }
+
+    public static <T> FlowableSubscriber<T> create(
+            FlowableSubscriber<T> subscriber,
+            String operationName,
+            Tracer tracer) {
+
+        return new TracingSubscriber<>(subscriber, operationName, tracer);
+    }
+}

--- a/opentracing-rxjava-2/src/test/java/io/opentracing/rxjava2/TestUtils.java
+++ b/opentracing-rxjava-2/src/test/java/io/opentracing/rxjava2/TestUtils.java
@@ -13,20 +13,23 @@
  */
 package io.opentracing.rxjava2;
 
-import static io.opentracing.rxjava2.AbstractTracingObserver.COMPONENT_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 import io.reactivex.schedulers.Schedulers;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+
+import static io.opentracing.rxjava2.RxTracer.COMPONENT_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 class TestUtils {
 
@@ -68,6 +71,14 @@ class TestUtils {
             return integer % 2 == 0;
           }
         });
+  }
+
+  static Flowable<Integer> createSequentialFlowable(final MockTracer mockTracer) {
+    return createSequentialObservable(mockTracer).toFlowable(BackpressureStrategy.ERROR);
+  }
+
+  static Flowable<Integer> createParallelFlowable(final MockTracer mockTracer) {
+    return createParallelObservable(mockTracer).toFlowable(BackpressureStrategy.ERROR);
   }
 
   private static void sleep() {

--- a/opentracing-rxjava-2/src/test/java/io/opentracing/rxjava2/TracingSubscriberTest.java
+++ b/opentracing-rxjava-2/src/test/java/io/opentracing/rxjava2/TracingSubscriberTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.rxjava2;
+
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.opentracing.rxjava2.TestUtils.*;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.*;
+
+public class TracingSubscriberTest {
+
+    private static final MockTracer mockTracer = new MockTracer();
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        TracingRxJava2Utils.enableTracing(mockTracer);
+    }
+
+    @Test
+    public void sequential() {
+        TestSubscriber<Integer> testSubscriber = executeSequentialFlowable();
+
+        assertEquals(5, testSubscriber.valueCount());
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(1, spans.size());
+        checkSpans(spans);
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    @Test
+    public void two_sequential() {
+        TestSubscriber<Integer> testSubscriber1 = executeSequentialFlowable();
+        TestSubscriber<Integer> testSubscriber2 = executeSequentialFlowable();
+
+        assertEquals(5, testSubscriber1.valueCount());
+        assertEquals(5, testSubscriber2.valueCount());
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+
+        assertNotEquals(spans.get(0).context().traceId(), spans.get(1).context().traceId());
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    @Test
+    public void sequential_with_parent() {
+        final MockSpan parent = mockTracer.buildSpan("parent").start();
+        try (Scope ignored = mockTracer.activateSpan(parent)) {
+            TestSubscriber<Integer> testSubscriber1 = executeSequentialFlowable();
+            TestSubscriber<Integer> testSubscriber2 = executeSequentialFlowable();
+
+            assertEquals(5, testSubscriber1.valueCount());
+            assertEquals(5, testSubscriber2.valueCount());
+        }
+        parent.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(3, spans.size());
+
+        assertNotNull(parent);
+
+        for (MockSpan span : spans) {
+            assertEquals(parent.context().traceId(), span.context().traceId());
+        }
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    @Test
+    public void parallel() {
+        TestSubscriber<Integer> testSubscriber = executeParallelFlowable();
+
+        await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(mockTracer), equalTo(1));
+
+        assertEquals(5, testSubscriber.valueCount());
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(1, spans.size());
+        checkSpans(spans);
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    @Test
+    public void two_parallel() {
+        TestSubscriber<Integer> testSubscriber1 = executeParallelFlowable();
+        TestSubscriber<Integer> testSubscriber2 = executeParallelFlowable();
+
+        testSubscriber1.awaitTerminalEvent();
+        testSubscriber2.awaitTerminalEvent();
+
+        await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(mockTracer), equalTo(2));
+
+        assertEquals(5, testSubscriber1.valueCount());
+        assertEquals(5, testSubscriber2.valueCount());
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+
+        assertNotEquals(spans.get(0).context().traceId(), spans.get(1).context().traceId());
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    @Test
+    public void parallel_with_parent() {
+        final MockSpan parent = mockTracer.buildSpan("parallel_parent").start();
+        try (Scope ignored = mockTracer.activateSpan(parent)) {
+            TestSubscriber<Integer> testSubscriber1 = executeParallelFlowable();
+            TestSubscriber<Integer> testSubscriber2 = executeParallelFlowable();
+
+            testSubscriber1.awaitTerminalEvent();
+            testSubscriber2.awaitTerminalEvent();
+
+            assertEquals(5, testSubscriber1.valueCount());
+            assertEquals(5, testSubscriber2.valueCount());
+        }
+        parent.finish();
+
+        await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(mockTracer), equalTo(3));
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(3, spans.size());
+
+        assertNotNull(parent);
+
+        for (MockSpan span : spans) {
+            assertEquals(parent.context().traceId(), span.context().traceId());
+        }
+
+        assertNull(mockTracer.scopeManager().activeSpan());
+    }
+
+    private TestSubscriber<Integer> executeSequentialFlowable() {
+        Flowable<Integer> Flowable = createSequentialFlowable(mockTracer);
+
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+
+        Flowable.subscribe(TracingSubscriber.create(subscriber, "sequential", mockTracer));
+
+        return subscriber;
+    }
+
+    private TestSubscriber<Integer> executeParallelFlowable() {
+        Flowable<Integer> flowable = createParallelFlowable(mockTracer);
+
+        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
+
+        flowable.subscribe(TracingSubscriber.create(subscriber, "parallel", mockTracer));
+
+        return subscriber;
+    }
+}


### PR DESCRIPTION
I've added TracingSubscriber (implementing FlowableSubscriber) which covers use cases where you need support for managing back-pressure.
As part of this I have renamed AbstractTracingObserver to RxTracer and made it a field of the implementations rather than inheriting it, which means we can use the same code for the TracingSubscriber as well as the TracingObserver - I've checked that this does not affect the public API as this was already package private.

I have had to make a change to the design for TracingSubscriber in how it is created, by adding static `create` methods for the various possibilities matching Flowable.subscribe(...). This is mostly because I don't really understand the purpose of TracingConsumer and I wouldn't know what to call a Subscriber equivalent to this (they also use Consumers underneath so it could get confusing!).

An example of wrapping an existing subscriber currently looks like:
```
        Flowable<Integer> flowable = createSequentialFlowable(mockTracer);
        TestSubscriber<Integer> subscriber = new TestSubscriber<>();
        flowable.subscribe(TracingSubscriber.create(subscriber, "sequential", mockTracer));
```
and an example of creating a TracingSubscriber directly:
```
        Flowable<Integer> flowable = createSequentialFlowable(mockTracer).subscribe(
                TracingSubscriber.create(o -> { System.out.println(o); }, "sequential", mockTracer)
        );
```

Unless I am missing the reason for it's existence, I would consider deprecating/removing TracingConsumer and replacing it with static `create` methods on TracingObserver.

If you have suggestions, please let me know!